### PR TITLE
Make return type of extractor be checked against user supplied options type

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -70,7 +70,7 @@ options:
     }
     rest: string[]
   }
-  const reader = new ArgvReader<'rest', ParsingTopOpts>(
+  const reader = new ArgvReader<'rest', ParsingTopOpts, ParsingTopOpts>(
     (arg, state) => {
       if (state === 'rest') {
         return ['argument', 'rest']
@@ -93,7 +93,7 @@ options:
       }
       return false
     },
-    opts => opts as ParsingTopOpts
+    opts => opts
   )
   const parsing = handleCommandlineError(() => reader.read(argv), () => help)
   if (parsing.arguments.command == null || parsing.arguments.command.length === 0) {
@@ -160,7 +160,7 @@ tool-workdir:
     }
     rest: string[]
   }
-  const reader = new ArgvReader<null | 'tool1' | 'tool1-v' | 'tool2' | 'tool2-v', ParsingBuildOpts>(
+  const reader = new ArgvReader<null | 'tool1' | 'tool1-v' | 'tool2' | 'tool2-v', ParsingBuildOpts, ParsingBuildOpts>(
     (arg, state) => {
       if (arg === '--') {
         return ['rest', null]
@@ -223,7 +223,7 @@ tool-workdir:
           return false
       }
     },
-    opts => opts as ParsingBuildOpts
+    opts => opts
   )
   const parsing = handleCommandlineError(() => reader.read(argv), () => help)
   if (parsing.arguments.tool1workdir == null || parsing.arguments.tool1workdir.length === 0) {
@@ -280,7 +280,7 @@ options:
       version?: string
     }
   }
-  const reader = new ArgvReader(
+  const reader = new ArgvReader<unknown, ParsingReleaseOpts, ParsingReleaseOpts>(
     arg => {
       if (arg.startsWith('-')) {
         if (arg === '--') {
@@ -299,7 +299,7 @@ options:
       }
       throw new ApplicationCommandlineError(new InvalidOptionValueError(`can not take any arguments: ${arg}`, 'expect-no-argument', 'argument', arg), () => help)
     },
-    opts => opts as ParsingReleaseOpts
+    opts => opts
   )
   const parsing = handleCommandlineError(() => reader.read(argv), () => help)
   if (parsing.singles.app == null) {

--- a/tests/argv-reader.test.ts
+++ b/tests/argv-reader.test.ts
@@ -16,20 +16,20 @@ describe('argv-reader', () => {
           optional1?: string,
         },
         multiples: {
-          multiple1?: string,
+          multiple1?: string[],
         },
         arguments: {
-          argument1?: string,
+          argument1?: string[],
         },
         rest: string[]
       }
       const context: {
-        reader: ArgvReader<unknown, RawOpts>
+        reader: ArgvReader<unknown, RawOpts, RawOpts>
       } = {
         reader: null!
       }
       beforeAll(() => {
-        context.reader = new ArgvReader<unknown, RawOpts>(
+        context.reader = new ArgvReader<unknown, RawOpts, RawOpts>(
           arg => {
             if (arg.startsWith('-')) {
               if (arg === '--') {
@@ -55,7 +55,7 @@ describe('argv-reader', () => {
             }
             return false
           },
-          opts => opts as RawOpts,
+          opts => opts,
         )
       })
       it('parses a short flag', () => {
@@ -140,12 +140,12 @@ describe('argv-reader', () => {
         rest: string[]
       }
       const context: {
-        reader: ArgvReader<'rest', RawOpts>
+        reader: ArgvReader<'rest', RawOpts, RawOpts>
       } = {
         reader: null!
       }
       beforeAll(() => {
-        context.reader = new ArgvReader<'rest', RawOpts>(
+        context.reader = new ArgvReader<'rest', RawOpts, RawOpts>(
           (arg, state) => {
             if (state === 'rest') {
               return ['argument', 'rest']
@@ -161,7 +161,7 @@ describe('argv-reader', () => {
             }
             return false
           },
-          opts => opts as RawOpts,
+          opts => opts,
         )
       })
       it('takes the first argument as the argument of command', () => {
@@ -187,12 +187,12 @@ describe('argv-reader', () => {
         },
       }
       const context: {
-        reader: ArgvReader<null | 'verbatim', RawOpts>
+        reader: ArgvReader<null | 'verbatim', RawOpts, RawOpts>
       } = {
         reader: null!
       }
       beforeAll(() => {
-        context.reader = new ArgvReader<null | 'verbatim', RawOpts>(
+        context.reader = new ArgvReader<null | 'verbatim', RawOpts, RawOpts>(
           (arg, state) => {
             if (state === 'verbatim') {
               return ['argument', 'argument1', null]
@@ -209,7 +209,7 @@ describe('argv-reader', () => {
               return ['argument', 'argument1']
             }
           },
-          opts => opts as RawOpts,
+          opts => opts,
         )
       })
       it('takes the first argument as the argument of command', () => {


### PR DESCRIPTION
Background:
* Names of flags or options are easy to misspell.

Changed:
* Introduce a type parameter representing an intermediate options type in addition to the final options type to `ArgvReader`.
* Keys of the intermediate options type is used to check names of flags or options returned from an extractor.
* A converter receives this intermediate options type instead of the raw options type.
* The existing final options type remains the return type of the converter and thus `read()`.