### PR TITLE
Support struct as extractor return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,39 @@ console.log(opts)
   }
   ```
 
+### Return structs instead of tuples
+
+* Extractors can return structs instead of tuples. The former is more readable in some cases.  
+  For example:
+
+  ```
+  return { type: 'rest' }
+  return { type: 'rest', state: 'state1' }
+  return { type: 'skip' }
+  return { type: 'skip', state: 'state1' }
+  return { type: 'flag', name: 'flag1' }
+  return { type: 'flag', name: 'flag1', state: 'state1' }
+  return { type: 'multiflag', name: 'multiflag1' }
+  return { type: 'multiflag', name: 'multiflag1', state: 'state1' }
+  return { type: 'noflag', name: 'flag1' }
+  return { type: 'noflag', name: 'flag1', state: 'state1' }
+  return { type: 'single', name: 'single1' }
+  return { type: 'single', name: 'single1', state: 'state1' }
+  return { type: 'multiple', name: 'multiple1' }
+  return { type: 'multiple', name: 'multiple1', state: 'state1' }
+  return { type: 'argument', name: 'argument1' }
+  return { type: 'argument', name: 'argument1', state: 'state1' }
+  return { type: 'replace', replace: ['replacer'] }
+  return { type: 'replace', replace: ['replacer'], state: 'state1' }
+  return {
+    type: 'lookahead',
+    lookahead: la => la == null || la.startsWith('-')
+      ? { type: 'replace', replace: [arg, ''] }
+      : { type: 'single', name: 'optional1' }
+  }
+  ```
+
+
 ## What this library does not provide
 
 ### Check if invalid values are given to options

--- a/tests/argv-reader.test.ts
+++ b/tests/argv-reader.test.ts
@@ -3,7 +3,7 @@ import { InvalidOptionError } from '../lib/exception'
 
 describe('argv-reader', () => {
   describe('ArgvReader', () => {
-    describe('parse options', () => {
+    describe('parse options by returning tuple', () => {
       type RawOpts = {
         flags: {
           flag1?: boolean,
@@ -132,7 +132,139 @@ describe('argv-reader', () => {
         expect(() => context.reader.read(['-?'])).toThrowError(/unknown option: -\?/)
       })
     })
-    describe('parse arguments', () => {
+    describe('parse options by returning struct', () => {
+      type RawOpts = {
+        flags: {
+          flag1?: boolean,
+        },
+        multiflags: {
+          multiflag1?: number,
+        },
+        singles: {
+          single1?: string,
+          optional1?: string,
+        },
+        multiples: {
+          multiple1?: string[],
+        },
+        arguments: {
+          argument1?: string[],
+        },
+        rest: string[]
+      }
+      const context: {
+        reader: ArgvReader<unknown, RawOpts, RawOpts>
+      } = {
+        reader: null!
+      }
+      beforeAll(() => {
+        context.reader = new ArgvReader<unknown, RawOpts, RawOpts>(
+          arg => {
+            if (arg.startsWith('-')) {
+              if (arg === '--') {
+                return { type: 'rest' }
+              }
+              switch (arg) {
+                case '-f': case '--flag1':
+                  return { type: 'flag', name: 'flag1' }
+                case '-F': case '--no-flag1':
+                  return { type: 'noflag', name: 'flag1' }
+                case '-v': case '--multiflag1':
+                  return { type: 'multiflag', name: 'multiflag1' }
+                case '-s': case '--single':
+                  return { type: 'single', name: 'single1' }
+                case '-o': case '--optional':
+                  return {
+                    type: 'lookahead',
+                    lookahead: la => la == null || la.startsWith('-')
+                      ? { type: 'replace', replace: [arg, ''] }
+                      : { type: 'single', name: 'optional1' }
+                  }
+                case '-m': case '--multiple':
+                  return { type: 'multiple', name: 'multiple1' }
+              }
+              throw new InvalidOptionError(`unknown option: ${arg}`, arg, 'unknown-option')
+            }
+            return false
+          },
+          opts => opts,
+        )
+      })
+      it('parses a short flag', () => {
+        const opts = context.reader.read(['-f'])
+        expect(opts.flags.flag1).toBeTruthy()
+      })
+      it('parses a long flag', () => {
+        const opts = context.reader.read(['--flag1'])
+        expect(opts.flags.flag1).toBeTruthy()
+      })
+      it('parses a short negative flag', () => {
+        const opts = context.reader.read(['-f', '-F'])
+        expect(opts.flags.flag1).toBeFalsy()
+      })
+      it('parses a long negativeflag', () => {
+        const opts = context.reader.read(['--flag1', '--no-flag1'])
+        expect(opts.flags.flag1).toBeFalsy()
+      })
+      it('parses a short cumulative flag', () => {
+        const opts = context.reader.read(['-v', '-v'])
+        expect(opts.multiflags.multiflag1).toEqual(2)
+      })
+      it('parses a long cumulativeflag', () => {
+        const opts = context.reader.read(['--multiflag1', '--multiflag1'])
+        expect(opts.multiflags.multiflag1).toEqual(2)
+      })
+      it('parses a short option taking a value', () => {
+        const opts = context.reader.read(['-s', 'a-value'])
+        expect(opts.singles.single1).toEqual('a-value')
+      })
+      it('parses a long option taking a value', () => {
+        const opts = context.reader.read(['--single', 'a-value'])
+        expect(opts.singles.single1).toEqual('a-value')
+      })
+      it('parses a short option taking multiple values', () => {
+        const opts = context.reader.read(['-m', 'value1', '-m', 'value2'])
+        expect(opts.multiples.multiple1).toEqual(['value1', 'value2'])
+      })
+      it('parses a long option taking multiple values', () => {
+        const opts = context.reader.read(['--multiple', 'value1', '--multiple', 'value2'])
+        expect(opts.multiples.multiple1).toEqual(['value1', 'value2'])
+      })
+      it('parses a short option taking an optional value which is given', () => {
+        const opts = context.reader.read(['-o', 'a-value'])
+        expect(opts.singles.optional1).toEqual('a-value')
+      })
+      it('parses a long option taking an optional value which is given', () => {
+        const opts = context.reader.read(['--optional', 'a-value'])
+        expect(opts.singles.optional1).toEqual('a-value')
+      })
+      it('parses a short option taking an optional value which is not given', () => {
+        const opts = context.reader.read(['-o', '--'])
+        expect(opts.singles.optional1).toEqual('')
+      })
+      it('parses a long option taking an optional value which is not given', () => {
+        const opts = context.reader.read(['--optional', '--'])
+        expect(opts.singles.optional1).toEqual('')
+      })
+      it('parses rest arguments', () => {
+        const opts = context.reader.read(['-f', 'a', 'b', 'c'])
+        expect(opts.rest).toEqual(['a', 'b', 'c'])
+      })
+      it('parses rest arguments after the rest marker', () => {
+        const opts = context.reader.read(['-f', 'a', 'b', 'c', '--', '-1', '-2'])
+        expect(opts.rest).toEqual(['a', 'b', 'c', '-1', '-2'])
+      })
+      it('throws if an option taking a value is not followed by its argument', () => {
+        expect(() => context.reader.read(['-s'])).toThrowError(/argument of single1 is not specified/)
+      })
+      it('throws if an option taking multiple values is not followed by its argument', () => {
+        expect(() => context.reader.read(['-m'])).toThrowError(/argument of multiple1 is not specified/)
+      })
+      it('throws if an option is unknown', () => {
+        expect(() => context.reader.read(['-?'])).toThrowError(/unknown option: -\?/)
+      })
+    })
+    describe('parse arguments by returning tuple', () => {
       type RawOpts = {
         arguments: {
           argument1?: string[],
@@ -180,7 +312,55 @@ describe('argv-reader', () => {
         expect(opts.rest).toEqual(['a', 'b', '--', 'c'])
       })
     })
-    describe('parse plural arguments', () => {
+    describe('parse arguments by returning struct', () => {
+      type RawOpts = {
+        arguments: {
+          argument1?: string[],
+        },
+        rest: string[]
+      }
+      const context: {
+        reader: ArgvReader<'rest', RawOpts, RawOpts>
+      } = {
+        reader: null!
+      }
+      beforeAll(() => {
+        context.reader = new ArgvReader<'rest', RawOpts, RawOpts>(
+          (arg, state) => {
+            if (state === 'rest') {
+              return { type: 'argument', name: 'rest' }
+            }
+            if (arg.startsWith('-')) {
+              if (arg === '--') {
+                return { type: 'rest' }
+              }
+              throw new InvalidOptionError(`unknown option: ${arg}`, arg, 'unknown-option')
+            }
+            if (state == null) {
+              return { type: 'argument', name: 'argument1', state: 'rest' }
+            }
+            return false
+          },
+          opts => opts,
+        )
+      })
+      it('takes the first argument as the argument of command', () => {
+        const opts = context.reader.read(['a'])
+        expect(opts.arguments.argument1).toEqual(['a'])
+        expect(opts.rest).toEqual([])
+      })
+      it('takes the first argument as the argument of command and takes the rest as the rest arguments', () => {
+        const opts = context.reader.read(['a', 'b', '--', 'c'])
+        expect(opts.arguments.argument1).toEqual(['a'])
+        expect(opts.rest).toEqual(['b', '--', 'c'])
+      })
+      it('sees the rest marker and takes all arguments after that as the rest arguments', () => {
+        const opts = context.reader.read(['--', 'a', 'b', '--', 'c'])
+        expect(opts.arguments.argument1).toBeUndefined()
+        expect(opts.rest).toEqual(['a', 'b', '--', 'c'])
+      })
+    })
+    describe('parse plural arguments by returning tuple', () => {
       type RawOpts = {
         arguments: {
           argument1?: string[],
@@ -225,6 +405,51 @@ describe('argv-reader', () => {
         expect(opts.arguments.argument1).toEqual(['-a', '--'])
       })
     })
+    describe('parse plural arguments by returning struct', () => {
+      type RawOpts = {
+        arguments: {
+          argument1?: string[],
+        },
+      }
+      const context: {
+        reader: ArgvReader<null | 'verbatim', RawOpts, RawOpts>
+      } = {
+        reader: null!
+      }
+      beforeAll(() => {
+        context.reader = new ArgvReader<null | 'verbatim', RawOpts, RawOpts>(
+          (arg, state) => {
+            if (state === 'verbatim') {
+              return { type: 'argument', name: 'argument1', state: null }
+            } else {
+              if (arg.startsWith('-')) {
+                if (arg === '--') {
+                  return { type: 'rest' }
+                }
+                if (arg === '-@') {
+                  return { type: 'skip', state: 'verbatim' }
+                }
+                throw new InvalidOptionError(`unknown option: ${arg}`, arg, 'unknown-option')
+              }
+              return { type: 'argument', name: 'argument1' }
+            }
+          },
+          opts => opts,
+        )
+      })
+      it('takes the first argument as the argument of command', () => {
+        const opts = context.reader.read(['a'])
+        expect(opts.arguments.argument1).toEqual(['a'])
+      })
+      it('takes the first two arguments  as the argument of command', () => {
+        const opts = context.reader.read(['a', 'b'])
+        expect(opts.arguments.argument1).toEqual(['a', 'b'])
+      })
+      it('reads verbatim arguments', () => {
+        const opts = context.reader.read(['-@', '-a', '-@', '--'])
+        expect(opts.arguments.argument1).toEqual(['-a', '--'])
+      })
+    })
     describe('abort', () => {
       type RawOpts = {
       }
@@ -234,15 +459,27 @@ describe('argv-reader', () => {
         reader: null!
       }
       beforeAll(() => {
-        context.reader = new ArgvReader<unknown, RawOpts>(
-          _ => {
-            return '?' as any
+        context.reader = new ArgvReader<unknown, RawOpts, RawOpts>(
+          x => {
+            if (x === 'tuple') {
+              return ['?'] as any
+            } else if (x === 'struct') {
+              return { type: '?' } as any
+            } else {
+              return '?' as any
+            }
           },
-          opts => opts as RawOpts,
+          opts => opts,
         )
       })
       it('aborts if invalid action is returned', () => {
-        expect(() => context.reader.read([''])).toThrowError(/unknown arg type/)
+        expect(() => context.reader.read(['scalar'])).toThrowError(/unknown arg type/)
+      })
+      it('aborts if invalid action tuple is returned', () => {
+        expect(() => context.reader.read(['tuple'])).toThrowError(/unknown arg type/)
+      })
+      it('aborts if invalid action struct is returned', () => {
+        expect(() => context.reader.read(['struct'])).toThrowError(/unknown arg type/)
       })
     })
   })


### PR DESCRIPTION
Background:
* Sometimes typescript is confused in inferring types from a union of tuples.
    - For example:
      ```
      type X<T> = ['a', T?] | ['b', number, T?]
      type F<T> = () => X<T>
      class C<T> {
        constructor(f: F<T>) { }
      }
      const c1 = new C(() => ['a'])
      // c1 is inferred as C<unknown>
      const c2 = new C(() => ['b', 1])
      // c2 is inferred as C<number>, not C<unknown>
      ```
* Using objects (call structs here) can avoid this.
* Structs are more readable in some cases.

Changed:
* Support returning structs from extractors, like:
  ```
  return { type: 'flag', name: 'flag1' }
  ```
  instead of
  ```
  return ['flag', 'flag1']
  ```
* Returning tuples will continue to be supported.

